### PR TITLE
chore: setup publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,32 +3,13 @@ plugins {
     alias libs.plugins.android.library apply false
     alias libs.plugins.jetbrains.kotlin.android apply false
     alias libs.plugins.jetbrains.compose apply false
-    alias libs.plugins.nexus.publish
+    alias libs.plugins.com.vanniktech.maven.publish apply false
+    alias libs.plugins.nl.littlerobots.version.catalog.update
 }
 
-tasks.register('clean', Delete) {
-    group = "clean"
-    delete(rootProject.layout.buildDirectory.get())
-}
+apply from: rootProject.layout.projectDirectory.file("gradle/resolve-all-dependencies.gradle")
 
-tasks.register('cleanPublish', Delete) {
-    group = "clean"
-    delete(rootProject.layout.projectDirectory.dir("releases"))
-}
-
-def localProperty = new Properties()
-def localPropertyFile = new File(rootDir, "local.properties")
-if (localPropertyFile.exists()) {
-    localProperty.load(localPropertyFile.newDataInputStream())
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
-            username.set(localProperty.getProperty("sonatype.username") ?: System.getenv("SONATYPE_USERNAME"))
-            password.set(localProperty.getProperty("sonatype.password") ?: System.getenv("SONATYPE_PASSWORD"))
-        }
-    }
+allprojects {
+    group = "io.github.ryunen344.tenugui"
+    version = providers.fileContents(rootProject.layout.projectDirectory.file("version.txt")).asText.getOrElse("snapshot").trim()
 }

--- a/gradle/cache-settings.gradle
+++ b/gradle/cache-settings.gradle
@@ -1,9 +1,0 @@
-// https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home:configure_cache_cleanup
-beforeSettings { settings ->
-    settings.caches {
-        releasedWrappers.removeUnusedEntriesAfterDays = 1
-        snapshotWrappers.removeUnusedEntriesAfterDays = 1
-        downloadedResources.removeUnusedEntriesAfterDays = 1
-        createdResources.removeUnusedEntriesAfterDays = 1
-    }
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,8 @@ androidx-compose-material3 = "1.3.1"
 material = "1.12.0"
 robolectric = "4.13"
 dropshots = "0.4.2"
+maven-publish = "0.31.0"
+version-catalog-update = "0.8.5"
 
 [libraries]
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
@@ -51,6 +53,8 @@ org-robolectric-robolectric = { group = "org.robolectric", name = "robolectric",
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+com-vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
+nl-littlerobots-version-catalog-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "version-catalog-update" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 jetbrains-kotlin-plugin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize" }
 jetbrains-kotlinx-compatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,53 +1,42 @@
-pluginManager.apply("maven-publish")
+pluginManager.apply("com.vanniktech.maven.publish")
 pluginManager.apply("signing")
 
 def localProperty = new Properties()
-def localPropertyFile = new File(rootDir, "local.properties")
+def localPropertyFile = rootProject.layout.projectDirectory.file("local.properties").asFile
 if (localPropertyFile.exists()) {
     localProperty.load(localPropertyFile.newDataInputStream())
 }
 
-group = "io.github.ryunen344.tenugui"
-version = providers.fileContents(rootProject.layout.projectDirectory.file("version.txt")).asText.orNull?.trim() ?: "snapshot"
-
-android.publishing {
-    singleVariant("release") {
-        withSourcesJar()
-        withJavadocJar()
-    }
-}
-
 afterEvaluate {
-    publishing {
-        publications {
-            release(MavenPublication) {
-                pom {
-                    name.set(project.findProperty("POM_NAME"))
-                    description.set(project.findProperty("POM_DESCRIPTION"))
-                    url.set("https://github.com/RyuNen344/Tenugui")
-                    licenses {
-                        license {
-                            name.set("Apache License 2.0")
-                            url.set("https://github.com/RyuNen344/Tenugui/blob/main/LICENSE")
-                            distribution.set("repo")
-                        }
-                    }
-                    developers {
-                        developer {
-                            id.set("RyuNen344")
-                            name.set("RyuNen344")
-                            email.set("s1100633@outlook.com")
-                        }
-                    }
-                    scm {
-                        connection.set("scm:git://github.com/RyuNen344/Tenugui.git")
-                        developerConnection.set("scm:git:ssh://github.com/RyuNen344/Tenugui.git")
-                        url.set("https://github.com/RyuNen344/Tenugui")
-                    }
+    mavenPublishing {
+        pom {
+            inceptionYear = "2025"
+            url = "https://github.com/RyuNen344/Tenugui"
+            licenses {
+                license {
+                    name = "Apache-2.0"
+                    url = "https://github.com/RyuNen344/Tenugui/blob/main/LICENSE.md"
+                    distribution = "repo"
                 }
-                from components.release
+            }
+            developers {
+                developer {
+                    id = "RyuNen344"
+                    name = "RyuNen344"
+                    email = "s1100633@outlook.com"
+                }
+            }
+            scm {
+                url = "https://github.com/RyuNen344/Tenugui"
+                connection = "scm:git://github.com/RyuNen344/Tenugui.git"
+                developerConnection = "scm:git:ssh://github.com/RyuNen344/Tenugui.git"
             }
         }
+
+        publishToMavenCentral("CENTRAL_PORTAL")
+    }
+
+    publishing {
         repositories {
             maven {
                 name = "Local"

--- a/gradle/resolve-all-dependencies.gradle
+++ b/gradle/resolve-all-dependencies.gradle
@@ -1,0 +1,186 @@
+import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
+import org.gradle.internal.serialization.Cached
+import org.gradle.work.DisableCachingByDefault
+
+import java.lang.reflect.Method
+
+@DisableCachingByDefault(because = "Not worth caching")
+abstract class ResolveProjectClasspathDependenciesTask extends DefaultTask {
+
+    ResolveProjectClasspathDependenciesTask() {
+        group = "help"
+        description = "Resolve Project Classpath Dependencies"
+    }
+
+    @OutputFile
+    final abstract RegularFileProperty outputFile = project.objects.fileProperty().convention(
+        project.layout.buildDirectory.dir("reports").map { it.dir("dependency") }.map { it.file("resolved-classpath-dependencies.txt") }
+    )
+
+    @Internal
+    Cached<List<ResolvedComponentResult>> configurationResolvers = Cached.of {
+        project.getBuildscript().getConfigurations()
+            .named(ScriptHandler.CLASSPATH_CONFIGURATION).get()
+            .incoming.resolutionResult.allComponents
+            .collectMany { component ->
+                component.dependencies.findAll {
+                    !(it.getRequested() instanceof DefaultProjectComponentSelector)
+                }
+            }
+            .toList() as List<ResolvedComponentResult>
+    }
+
+    @TaskAction
+    void action() {
+        def outputFile = outputFile.get().asFile
+        if (outputFile.exists()) {
+            outputFile.delete()
+        }
+        outputFile.createNewFile()
+
+        def resolvedDependencies = configurationResolvers.get()
+            .findAll { !(it.getRequested() instanceof DefaultProjectComponentSelector) }
+            .unique { a, b -> a.toString() <=> b.toString() }
+            .sort { a -> a.toString() }
+
+        outputFile.withWriter { writer ->
+            resolvedDependencies.forEach { dependency ->
+                writer.writeLine("$dependency")
+            }
+        }
+    }
+}
+
+@DisableCachingByDefault(because = "Not worth caching")
+abstract class ResolveProjectDependencyTask extends DefaultTask {
+
+    ResolveProjectDependencyTask() {
+        group = "help"
+        description = "Resolve Project Dependencies"
+    }
+
+    @OutputFile
+    final abstract RegularFileProperty outputFile = project.objects.fileProperty().convention(
+        project.layout.buildDirectory.dir("reports").map { it.dir("dependency") }.map { it.file("resolved-dependencies.txt") }
+    )
+
+    @Internal
+    Cached<List<ResolvedComponentResult>> configurationResolvers = Cached.of {
+        getConfigurations().collectMany { configuration ->
+            configuration.incoming.resolutionResult.allComponents
+                .collectMany { component ->
+                    component.dependencies.findAll {
+                        !(it.getRequested() instanceof DefaultProjectComponentSelector)
+                    }
+                }
+                .toList()
+        } as List<ResolvedComponentResult>
+    }
+
+    @Internal
+    List<Configuration> getConfigurations() {
+        def canSafelyBeResolvedMethod = getCanSafelyBeResolvedMethod()
+        return project.configurations.findAll {
+            canSafelyBeResolved(canSafelyBeResolvedMethod, it)
+        }.toList()
+    }
+
+    @TaskAction
+    void action() {
+        def outputFile = outputFile.get().asFile
+        if (outputFile.exists()) {
+            outputFile.delete()
+        }
+        outputFile.createNewFile()
+
+        def resolvedDependencies = configurationResolvers.get()
+            .findAll { !(it.getRequested() instanceof DefaultProjectComponentSelector) }
+            .unique { a, b -> a.toString() <=> b.toString() }
+            .sort { a -> a.toString() }
+
+        outputFile.withWriter { writer ->
+            resolvedDependencies.forEach { dependency ->
+                writer.writeLine("$dependency")
+            }
+        }
+    }
+
+    static boolean canSafelyBeResolved(Method canSafelyBeResolvedMethod, Configuration configuration) {
+        if (canSafelyBeResolvedMethod != null) {
+            try {
+                return canSafelyBeResolvedMethod.invoke(configuration)
+            } catch (ReflectiveOperationException ignored) {
+                return false
+            }
+        }
+        return configuration.canBeResolved
+    }
+
+    static Method getCanSafelyBeResolvedMethod() {
+        try {
+            def dc = Class.forName("org.gradle.internal.deprecation.DeprecatableConfiguration")
+            return dc.getMethod("canSafelyBeResolved")
+        } catch (ReflectiveOperationException e) {
+            return null
+        }
+    }
+}
+
+@DisableCachingByDefault(because = "Not worth caching")
+abstract class ResolveAllDependenciesTask extends DefaultTask {
+
+    ResolveAllDependenciesTask() {
+        group = "help"
+        description = "Resolve All Project Dependencies"
+    }
+
+    @OutputFile
+    final abstract RegularFileProperty outputFile = project.objects.fileProperty().convention(
+        project.layout.buildDirectory.dir("reports").map { it.dir("dependency") }.map { it.file("resolved-all-dependencies.txt") }
+    )
+
+    @InputFiles
+    final abstract ConfigurableFileCollection inputFiles = project.objects.fileCollection()
+
+    @TaskAction
+    void action() {
+        def outputFile = outputFile.get().asFile
+        if (outputFile.exists()) {
+            outputFile.delete()
+        }
+        outputFile.createNewFile()
+
+        def inputFiles = inputFiles.files
+        if (inputFiles.isEmpty()) return
+
+        def resolvedDependencies = inputFiles
+            .collect { file -> file.readLines() }
+            .flatten()
+            .unique()
+            .sort()
+
+        outputFile.withWriter { writer ->
+            resolvedDependencies.forEach { dependency ->
+                writer.writeLine("$dependency")
+            }
+        }
+    }
+}
+
+gradle.projectsEvaluated {
+    def outputs = []
+    def resolveAllDepTask = gradle.rootProject.tasks.register("resolveAllDependencies", ResolveAllDependenciesTask)
+    gradle.allprojects { project ->
+        def resolveProjectClasspathTask = project.tasks.register("resolveProjectClasspathDependencies", ResolveProjectClasspathDependenciesTask)
+        def resolveProjectDependencyTask = project.tasks.register("resolveProjectDependencies", ResolveProjectDependencyTask)
+        outputs += resolveProjectClasspathTask.get().outputs.files.singleFile
+        outputs += resolveProjectDependencyTask.get().outputs.files.singleFile
+        resolveAllDepTask.configure {
+            dependsOn(resolveProjectClasspathTask)
+            dependsOn(resolveProjectDependencyTask)
+        }
+    }
+    resolveAllDepTask.configure {
+        inputFiles.from(outputs)
+    }
+}


### PR DESCRIPTION
This pull request includes several changes to the Gradle build configuration, focusing on updating dependencies, modifying the publishing configuration, and adding new tasks for resolving dependencies. The most important changes include the removal of cache settings, updates to the `libs.versions.toml` file, changes to the `publish.gradle` file, and the addition of new tasks in `resolve-all-dependencies.gradle`.

### Dependency Updates:

* Added new dependencies `maven-publish` and `version-catalog-update` to the `gradle/libs.versions.toml` file.
* Added new plugins `com-vanniktech-maven-publish` and `nl-littlerobots-version-catalog-update` to the `gradle/libs.versions.toml` file.

### Publishing Configuration:

* Changed the publishing plugin from `maven-publish` to `com.vanniktech.maven.publish` and updated the configuration in the `gradle/publish.gradle` file.

### Task Additions:

* Added new tasks `ResolveProjectClasspathDependenciesTask`, `ResolveProjectDependencyTask`, and `ResolveAllDependenciesTask` in the `gradle/resolve-all-dependencies.gradle` file to resolve and report project dependencies.

### Cache Settings Removal:

* Removed unused cache settings from the `gradle/cache-settings.gradle` file.