### PR TITLE
test: retry annotation visibility

### DIFF
--- a/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/rule/RetryRule.kt
+++ b/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/rule/RetryRule.kt
@@ -24,7 +24,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
-@Retention(AnnotationRetention.BINARY)
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
 annotation class Retry(val times: Int = 3, val timeout: Long = 300)
 
@@ -33,7 +33,7 @@ class RetryException(val errors: List<Throwable>) : RuntimeException(
         appendLine("Invoked test still failed after ${errors.size} retries.")
         errors.forEachIndexed { index, t ->
             appendLine("Attempt #$index threw exception")
-            appendLine(t.stackTraceToString())
+            append(t.stackTraceToString())
         }
     },
 )


### PR DESCRIPTION
This pull request includes updates to the `RetryRule` in the test rules for the project. The changes involve modifying the annotation retention policy and improving the exception message formatting.

The most important changes include:

Annotation Update:
* [`tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/rule/RetryRule.kt`](diffhunk://#diff-dd1ec2a3289a97bab96cacf0f86ee2a71c3feac7b0001fb74814c85154df244fL27-R27): Changed the retention policy of the `Retry` annotation from `BINARY` to `RUNTIME` to ensure it is available at runtime.

Exception Message Formatting:
* [`tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/rule/RetryRule.kt`](diffhunk://#diff-dd1ec2a3289a97bab96cacf0f86ee2a71c3feac7b0001fb74814c85154df244fL36-R36): Improved the formatting of the exception message in `RetryException` by appending the stack trace directly instead of using `appendLine`.