### PR TITLE
chore: main branch ci concurrency

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,8 +12,8 @@ on:
       - reopened
 
 concurrency:
-  group: check-${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'main')}}
+  group: dependency-report-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration to improve the handling of concurrent runs and dependency reporting.

Changes to GitHub Actions workflow configuration:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L15-R16): Updated the `concurrency` group name to `dependency-report` and set `cancel-in-progress` to `true` for all branches.