### PR TITLE
chore: lint abortOnError on CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          ./gradlew lintDebug
+          ./gradlew lintDebug -PabortOnError
       - name: run detekt
         if: ${{ !cancelled() }}
         shell: bash
@@ -52,7 +52,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew lintFix detekt -PautoCorrect --quiet --continue || true;
+          ./gradlew lintFix detekt -PautoCorrect -PabortOnError --quiet --continue || true;
           TMPFILE=$(mktemp);
           git diff >"${TMPFILE}";
           git stash -u || git stash drop;

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew lintFix detekt -PautoCorrect -PabortOnError --quiet --continue || true;
+          ./gradlew lintFix detekt -PautoCorrect -PabortOnError --quiet --continue;
           TMPFILE=$(mktemp);
           git diff >"${TMPFILE}";
           git stash -u || git stash drop;

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -23,6 +23,7 @@ android {
         checkReleaseBuilds = false
         sarifReport = true
         baseline = rootProject.layout.projectDirectory.file(".lint/android-baseline.xml")
+        abortOnError = !project.providers.gradleProperty("abortOnError").present
     }
 }
 


### PR DESCRIPTION
This pull request includes changes to the linting and static analysis configuration to enforce stricter error handling during the build process. The most important changes include the addition of the `abortOnError` property to the Gradle lint task and the modification of workflow commands to utilize this property.

Changes to linting and static analysis configuration:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L36-R36): Modified the `lintDebug` command to include the `-PabortOnError` property, ensuring that the build process aborts on lint errors.
* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L55-R55): Updated the `lintFix detekt` command to include the `-PabortOnError` property, enforcing stricter error handling during the linting and static analysis steps.
* [`gradle/android.gradle`](diffhunk://#diff-5f2cd33383ca671d25981b9e9137b67aeac7aaa74eb9f47497146fc62e349927R26): Added the `abortOnError` property to the lint configuration, making it conditional on the presence of a Gradle property.