### PR TITLE
refactor: replace String dialogId with UUID

### DIFF
--- a/tenugui/api/tenugui.api
+++ b/tenugui/api/tenugui.api
@@ -172,7 +172,7 @@ public final class io/github/ryunen344/tenugui/BottomSheetDialogState$SavedState
 }
 
 public final class io/github/ryunen344/tenugui/BottomSheetDialogStateKt {
-	public static final fun rememberBottomSheetDialogState (Ljava/util/UUID;Ljava/lang/String;Landroid/os/Bundle;Landroid/os/Parcelable;Lio/github/ryunen344/tenugui/BottomSheetDialogProperties;Lio/github/ryunen344/tenugui/BottomSheetBehaviorProperties;Landroidx/compose/runtime/Composer;II)Lio/github/ryunen344/tenugui/BottomSheetDialogState;
+	public static final fun rememberBottomSheetDialogState (Ljava/lang/String;Landroid/os/Bundle;Landroid/os/Parcelable;Lio/github/ryunen344/tenugui/BottomSheetDialogProperties;Lio/github/ryunen344/tenugui/BottomSheetBehaviorProperties;Landroidx/compose/runtime/Composer;II)Lio/github/ryunen344/tenugui/BottomSheetDialogState;
 	public static final fun rememberBottomSheetDialogState-MV32uAI (Ljava/lang/String;Landroid/os/Bundle;Landroid/os/Parcelable;ZZZZLandroidx/compose/ui/window/SecureFlagPolicy;ZFZIIIFIZZZIIFLandroidx/compose/runtime/Composer;IIII)Lio/github/ryunen344/tenugui/BottomSheetDialogState;
 }
 

--- a/tenugui/api/tenugui.api
+++ b/tenugui/api/tenugui.api
@@ -87,7 +87,7 @@ public final class io/github/ryunen344/tenugui/BottomSheetBehaviorState {
 }
 
 public final class io/github/ryunen344/tenugui/BottomSheetDialogKt {
-	public static final fun BottomSheetDialog (Lkotlin/jvm/functions/Function0;Ljava/lang/String;Lio/github/ryunen344/tenugui/BottomSheetDialogState;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun BottomSheetDialog (Lkotlin/jvm/functions/Function0;Ljava/util/UUID;Lio/github/ryunen344/tenugui/BottomSheetDialogState;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/github/ryunen344/tenugui/BottomSheetDialogProperties : android/os/Parcelable {
@@ -172,13 +172,13 @@ public final class io/github/ryunen344/tenugui/BottomSheetDialogState$SavedState
 }
 
 public final class io/github/ryunen344/tenugui/BottomSheetDialogStateKt {
-	public static final fun rememberBottomSheetDialogState (Ljava/lang/String;Landroid/os/Bundle;Landroid/os/Parcelable;Lio/github/ryunen344/tenugui/BottomSheetDialogProperties;Lio/github/ryunen344/tenugui/BottomSheetBehaviorProperties;Landroidx/compose/runtime/Composer;II)Lio/github/ryunen344/tenugui/BottomSheetDialogState;
+	public static final fun rememberBottomSheetDialogState (Ljava/util/UUID;Ljava/lang/String;Landroid/os/Bundle;Landroid/os/Parcelable;Lio/github/ryunen344/tenugui/BottomSheetDialogProperties;Lio/github/ryunen344/tenugui/BottomSheetBehaviorProperties;Landroidx/compose/runtime/Composer;II)Lio/github/ryunen344/tenugui/BottomSheetDialogState;
 	public static final fun rememberBottomSheetDialogState-MV32uAI (Ljava/lang/String;Landroid/os/Bundle;Landroid/os/Parcelable;ZZZZLandroidx/compose/ui/window/SecureFlagPolicy;ZFZIIIFIZZZIIFLandroidx/compose/runtime/Composer;IIII)Lio/github/ryunen344/tenugui/BottomSheetDialogState;
 }
 
 public final class io/github/ryunen344/tenugui/BottomSheetDialogWrapper : com/google/android/material/bottomsheet/BottomSheetDialog, androidx/compose/ui/platform/ViewRootForInspector {
 	public static final field $stable I
-	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/github/ryunen344/tenugui/BottomSheetDialogProperties;Landroid/view/View;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/Density;Ljava/lang/String;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lio/github/ryunen344/tenugui/BottomSheetDialogProperties;Landroid/view/View;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/Density;Ljava/util/UUID;)V
 	public fun cancel ()V
 	public final fun disposeComposition ()V
 	public final fun getBottomSheet ()Landroid/widget/FrameLayout;

--- a/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialog.kt
+++ b/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialog.kt
@@ -47,8 +47,8 @@ import java.util.UUID
 @Composable
 public fun BottomSheetDialog(
     onDismissRequest: () -> Unit,
-    dialogId: String = rememberSaveable { UUID.randomUUID().toString() },
-    state: BottomSheetDialogState = rememberBottomSheetDialogState(key = dialogId),
+    dialogId: UUID = rememberSaveable { UUID.randomUUID() },
+    state: BottomSheetDialogState = rememberBottomSheetDialogState(dialogId = dialogId),
     content: @Composable () -> Unit,
 ) {
     val view = LocalView.current

--- a/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialog.kt
+++ b/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialog.kt
@@ -48,7 +48,7 @@ import java.util.UUID
 public fun BottomSheetDialog(
     onDismissRequest: () -> Unit,
     dialogId: UUID = rememberSaveable { UUID.randomUUID() },
-    state: BottomSheetDialogState = rememberBottomSheetDialogState(dialogId = dialogId),
+    state: BottomSheetDialogState = rememberBottomSheetDialogState(),
     content: @Composable () -> Unit,
 ) {
     val view = LocalView.current

--- a/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogState.kt
+++ b/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogState.kt
@@ -41,7 +41,6 @@ import io.github.ryunen344.tenugui.BottomSheetBehaviorProperties.Companion.DEFAU
 import io.github.ryunen344.tenugui.BottomSheetBehaviorProperties.Companion.HIDE_FRICTION
 import io.github.ryunen344.tenugui.BottomSheetBehaviorProperties.Companion.NO_MAX_SIZE
 import kotlinx.parcelize.Parcelize
-import java.util.UUID
 
 @Stable
 public class BottomSheetDialogState(
@@ -156,14 +155,13 @@ public class BottomSheetDialogState(
 
 @Composable
 public fun rememberBottomSheetDialogState(
-    dialogId: UUID,
     key: String? = null,
     dialogState: Bundle? = null,
     behaviorState: Parcelable? = null,
     dialogProperties: BottomSheetDialogProperties = rememberBottomSheetDialogProperties(key = key),
     behaviorProperties: BottomSheetBehaviorProperties = rememberBottomSheetBehaviorProperties(key = key),
 ): BottomSheetDialogState {
-    return rememberSaveable(dialogId, dialogProperties, behaviorProperties, saver = BottomSheetDialogStateSaver, key = key) {
+    return rememberSaveable(dialogProperties, behaviorProperties, saver = BottomSheetDialogStateSaver, key = key) {
         BottomSheetDialogState(
             savedState = BottomSheetDialogState.SavedState(dialogState, behaviorState),
             dialogProperties = dialogProperties,

--- a/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogState.kt
+++ b/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogState.kt
@@ -41,6 +41,7 @@ import io.github.ryunen344.tenugui.BottomSheetBehaviorProperties.Companion.DEFAU
 import io.github.ryunen344.tenugui.BottomSheetBehaviorProperties.Companion.HIDE_FRICTION
 import io.github.ryunen344.tenugui.BottomSheetBehaviorProperties.Companion.NO_MAX_SIZE
 import kotlinx.parcelize.Parcelize
+import java.util.UUID
 
 @Stable
 public class BottomSheetDialogState(
@@ -155,13 +156,14 @@ public class BottomSheetDialogState(
 
 @Composable
 public fun rememberBottomSheetDialogState(
+    dialogId: UUID,
     key: String? = null,
     dialogState: Bundle? = null,
     behaviorState: Parcelable? = null,
     dialogProperties: BottomSheetDialogProperties = rememberBottomSheetDialogProperties(key = key),
     behaviorProperties: BottomSheetBehaviorProperties = rememberBottomSheetBehaviorProperties(key = key),
 ): BottomSheetDialogState {
-    return rememberSaveable(dialogProperties, behaviorProperties, saver = BottomSheetDialogStateSaver, key = key) {
+    return rememberSaveable(dialogId, dialogProperties, behaviorProperties, saver = BottomSheetDialogStateSaver, key = key) {
         BottomSheetDialogState(
             savedState = BottomSheetDialogState.SavedState(dialogState, behaviorState),
             dialogProperties = dialogProperties,

--- a/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogWrapper.kt
+++ b/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogWrapper.kt
@@ -163,7 +163,7 @@ public class BottomSheetDialogWrapper(
 
                         BottomSheetBehavior.STATE_DRAGGING,
                         BottomSheetBehavior.STATE_SETTLING,
-                            -> {
+                        -> {
                             // noop
                         }
                     }
@@ -180,14 +180,14 @@ public class BottomSheetDialogWrapper(
 
                     BottomSheetBehavior.STATE_HALF_EXPANDED,
                     BottomSheetBehavior.STATE_HIDDEN,
-                        -> {
+                    -> {
                         behavior.state = BottomSheetBehavior.STATE_COLLAPSED
                     }
 
                     BottomSheetBehavior.STATE_COLLAPSED,
                     BottomSheetBehavior.STATE_DRAGGING,
                     BottomSheetBehavior.STATE_SETTLING,
-                        -> {
+                    -> {
                         // noop
                     }
                 }

--- a/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogWrapper.kt
+++ b/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogWrapper.kt
@@ -47,6 +47,7 @@ import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.motion.MaterialBackOrchestrator
+import java.util.UUID
 
 public class BottomSheetDialogWrapper(
     private var onDismissRequest: () -> Unit,
@@ -54,7 +55,7 @@ public class BottomSheetDialogWrapper(
     private val view: View,
     layoutDirection: LayoutDirection,
     density: Density,
-    dialogId: String,
+    dialogId: UUID,
 ) : BottomSheetDialog(
     ContextThemeWrapper(
         view.context,
@@ -162,7 +163,7 @@ public class BottomSheetDialogWrapper(
 
                         BottomSheetBehavior.STATE_DRAGGING,
                         BottomSheetBehavior.STATE_SETTLING,
-                        -> {
+                            -> {
                             // noop
                         }
                     }
@@ -179,14 +180,14 @@ public class BottomSheetDialogWrapper(
 
                     BottomSheetBehavior.STATE_HALF_EXPANDED,
                     BottomSheetBehavior.STATE_HIDDEN,
-                    -> {
+                        -> {
                         behavior.state = BottomSheetBehavior.STATE_COLLAPSED
                     }
 
                     BottomSheetBehavior.STATE_COLLAPSED,
                     BottomSheetBehavior.STATE_DRAGGING,
                     BottomSheetBehavior.STATE_SETTLING,
-                    -> {
+                        -> {
                         // noop
                     }
                 }

--- a/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/CollapsedTest.kt
+++ b/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/CollapsedTest.kt
@@ -56,7 +56,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -80,7 +79,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -104,7 +102,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -132,7 +129,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -156,7 +152,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -180,7 +175,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -208,7 +202,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -234,7 +227,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -260,7 +252,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -290,7 +281,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -316,7 +306,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -342,7 +331,6 @@ class CollapsedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),

--- a/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/CollapsedTest.kt
+++ b/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/CollapsedTest.kt
@@ -54,11 +54,11 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -78,11 +78,11 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -102,11 +102,11 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -130,11 +130,11 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -154,11 +154,11 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -178,11 +178,11 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -206,14 +206,13 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -233,14 +232,13 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -260,14 +258,13 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -291,14 +288,13 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -318,14 +314,13 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -345,14 +340,13 @@ class CollapsedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(

--- a/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/ExpandedTest.kt
+++ b/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/ExpandedTest.kt
@@ -55,12 +55,11 @@ class ExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
-                        key = dialogId,
                         skipCollapsed = true,
                     ),
                 )
@@ -82,12 +81,11 @@ class ExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
-                        key = dialogId,
                         skipCollapsed = true,
                     ),
                 )
@@ -110,12 +108,11 @@ class ExpandedTest {
             screenShotRule.device.waitForIdle()
             setContent {
                 MaterialTheme {
-                    val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                    val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        key = dialogId,
-                        dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
+                        dialogId = dialogId,
+                        dialogProperties = rememberBottomSheetDialogProperties(),
                         behaviorProperties = rememberBottomSheetBehaviorProperties(
-                            key = dialogId,
                             skipCollapsed = true,
                         ),
                     )
@@ -141,15 +138,13 @@ class ExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
-                        key = dialogId,
                         skipCollapsed = true,
                     ),
                 )
@@ -171,15 +166,13 @@ class ExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
-                        key = dialogId,
                         skipCollapsed = true,
                     ),
                 )
@@ -202,15 +195,13 @@ class ExpandedTest {
             screenShotRule.device.waitForIdle()
             setContent {
                 MaterialTheme {
-                    val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                    val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        key = dialogId,
+                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(
-                            key = dialogId,
                             decorFitsSystemWindows = false,
                         ),
                         behaviorProperties = rememberBottomSheetBehaviorProperties(
-                            key = dialogId,
                             skipCollapsed = true,
                         ),
                     )
@@ -236,12 +227,11 @@ class ExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
-                        key = dialogId,
                         maxHeight = 3000,
                         peekHeight = 3000,
                         skipCollapsed = true,
@@ -265,12 +255,11 @@ class ExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
-                        key = dialogId,
                         maxHeight = 3000,
                         peekHeight = 3000,
                         skipCollapsed = true,
@@ -295,12 +284,11 @@ class ExpandedTest {
             screenShotRule.device.waitForIdle()
             setContent {
                 MaterialTheme {
-                    val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                    val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        key = dialogId,
-                        dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
+                        dialogId = dialogId,
+                        dialogProperties = rememberBottomSheetDialogProperties(),
                         behaviorProperties = rememberBottomSheetBehaviorProperties(
-                            key = dialogId,
                             maxHeight = 3000,
                             peekHeight = 3000,
                             skipCollapsed = true,
@@ -328,15 +316,13 @@ class ExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
-                        key = dialogId,
                         maxHeight = 3000,
                         peekHeight = 3000,
                         skipCollapsed = true,
@@ -360,15 +346,13 @@ class ExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
-                        key = dialogId,
                         maxHeight = 3000,
                         peekHeight = 3000,
                         skipCollapsed = true,
@@ -393,15 +377,13 @@ class ExpandedTest {
             screenShotRule.device.waitForIdle()
             setContent {
                 MaterialTheme {
-                    val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                    val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        key = dialogId,
+                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(
-                            key = dialogId,
                             decorFitsSystemWindows = false,
                         ),
                         behaviorProperties = rememberBottomSheetBehaviorProperties(
-                            key = dialogId,
                             maxHeight = 3000,
                             peekHeight = 3000,
                             skipCollapsed = true,

--- a/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/ExpandedTest.kt
+++ b/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/ExpandedTest.kt
@@ -57,7 +57,6 @@ class ExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
                         skipCollapsed = true,
@@ -83,7 +82,6 @@ class ExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
                         skipCollapsed = true,
@@ -110,7 +108,6 @@ class ExpandedTest {
                 MaterialTheme {
                     val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(),
                         behaviorProperties = rememberBottomSheetBehaviorProperties(
                             skipCollapsed = true,
@@ -140,7 +137,6 @@ class ExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -168,7 +164,6 @@ class ExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -197,7 +192,6 @@ class ExpandedTest {
                 MaterialTheme {
                     val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(
                             decorFitsSystemWindows = false,
                         ),
@@ -229,7 +223,6 @@ class ExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
                         maxHeight = 3000,
@@ -257,7 +250,6 @@ class ExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(
                         maxHeight = 3000,
@@ -286,7 +278,6 @@ class ExpandedTest {
                 MaterialTheme {
                     val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(),
                         behaviorProperties = rememberBottomSheetBehaviorProperties(
                             maxHeight = 3000,
@@ -318,7 +309,6 @@ class ExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -348,7 +338,6 @@ class ExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -379,7 +368,6 @@ class ExpandedTest {
                 MaterialTheme {
                     val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(
                             decorFitsSystemWindows = false,
                         ),

--- a/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/HalfExpandedTest.kt
+++ b/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/HalfExpandedTest.kt
@@ -59,7 +59,6 @@ class HalfExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -86,7 +85,6 @@ class HalfExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -114,7 +112,6 @@ class HalfExpandedTest {
                 MaterialTheme {
                     val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(),
                         behaviorProperties = rememberBottomSheetBehaviorProperties(),
                     )
@@ -144,7 +141,6 @@ class HalfExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -171,7 +167,6 @@ class HalfExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(),
                     behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
@@ -199,7 +194,6 @@ class HalfExpandedTest {
                 MaterialTheme {
                     val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(),
                         behaviorProperties = rememberBottomSheetBehaviorProperties(),
                     )
@@ -229,7 +223,6 @@ class HalfExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -258,7 +251,6 @@ class HalfExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -288,7 +280,6 @@ class HalfExpandedTest {
                 MaterialTheme {
                     val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(
                             decorFitsSystemWindows = false,
                         ),
@@ -320,7 +311,6 @@ class HalfExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -349,7 +339,6 @@ class HalfExpandedTest {
             MaterialTheme {
                 val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
                         decorFitsSystemWindows = false,
                     ),
@@ -379,7 +368,6 @@ class HalfExpandedTest {
                 MaterialTheme {
                     val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(
                             decorFitsSystemWindows = false,
                         ),

--- a/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/HalfExpandedTest.kt
+++ b/tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/HalfExpandedTest.kt
@@ -57,11 +57,11 @@ class HalfExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -84,11 +84,11 @@ class HalfExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -112,11 +112,11 @@ class HalfExpandedTest {
             screenShotRule.device.waitForIdle()
             setContent {
                 MaterialTheme {
-                    val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                    val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        key = dialogId,
-                        dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                        behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                        dialogId = dialogId,
+                        dialogProperties = rememberBottomSheetDialogProperties(),
+                        behaviorProperties = rememberBottomSheetBehaviorProperties(),
                     )
 
                     BottomSheetDialog(
@@ -142,11 +142,11 @@ class HalfExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -169,11 +169,11 @@ class HalfExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
-                    dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    dialogId = dialogId,
+                    dialogProperties = rememberBottomSheetDialogProperties(),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -197,11 +197,11 @@ class HalfExpandedTest {
             screenShotRule.device.waitForIdle()
             setContent {
                 MaterialTheme {
-                    val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                    val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        key = dialogId,
-                        dialogProperties = rememberBottomSheetDialogProperties(key = dialogId),
-                        behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                        dialogId = dialogId,
+                        dialogProperties = rememberBottomSheetDialogProperties(),
+                        behaviorProperties = rememberBottomSheetBehaviorProperties(),
                     )
 
                     BottomSheetDialog(
@@ -227,14 +227,13 @@ class HalfExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -257,14 +256,13 @@ class HalfExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -288,14 +286,13 @@ class HalfExpandedTest {
             screenShotRule.device.waitForIdle()
             setContent {
                 MaterialTheme {
-                    val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                    val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        key = dialogId,
+                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(
-                            key = dialogId,
                             decorFitsSystemWindows = false,
                         ),
-                        behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                        behaviorProperties = rememberBottomSheetBehaviorProperties(),
                     )
 
                     BottomSheetDialog(
@@ -321,14 +318,13 @@ class HalfExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -351,14 +347,13 @@ class HalfExpandedTest {
         screenShotRule.device.waitForIdle()
         setContent {
             MaterialTheme {
-                val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                val dialogId = rememberSaveable { UUID.randomUUID() }
                 val state = rememberBottomSheetDialogState(
-                    key = dialogId,
+                    dialogId = dialogId,
                     dialogProperties = rememberBottomSheetDialogProperties(
-                        key = dialogId,
                         decorFitsSystemWindows = false,
                     ),
-                    behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                    behaviorProperties = rememberBottomSheetBehaviorProperties(),
                 )
 
                 BottomSheetDialog(
@@ -382,14 +377,13 @@ class HalfExpandedTest {
             screenShotRule.device.waitForIdle()
             setContent {
                 MaterialTheme {
-                    val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+                    val dialogId = rememberSaveable { UUID.randomUUID() }
                     val state = rememberBottomSheetDialogState(
-                        key = dialogId,
+                        dialogId = dialogId,
                         dialogProperties = rememberBottomSheetDialogProperties(
-                            key = dialogId,
                             decorFitsSystemWindows = false,
                         ),
-                        behaviorProperties = rememberBottomSheetBehaviorProperties(key = dialogId),
+                        behaviorProperties = rememberBottomSheetBehaviorProperties(),
                     )
 
                     BottomSheetDialog(

--- a/tests/src/main/java/io/github/ryunen344/tenugui/tests/ui/BottomSheetContent.kt
+++ b/tests/src/main/java/io/github/ryunen344/tenugui/tests/ui/BottomSheetContent.kt
@@ -98,14 +98,9 @@ fun BottomSheetContent(decorFitsSystemWindows: Boolean) {
     }
 
     if (visible) {
-        val dialogId = rememberSaveable { UUID.randomUUID().toString() }
+        val dialogId = rememberSaveable { UUID.randomUUID() }
         LocalDensity.current
-        val bottomSheetDialogState =
-            rememberBottomSheetDialogState(
-                key = dialogId,
-                decorFitsSystemWindows = decorFitsSystemWindows,
-            )
-
+        val bottomSheetDialogState = rememberBottomSheetDialogState(decorFitsSystemWindows = decorFitsSystemWindows)
         val behaviorState by bottomSheetDialogState.behavior.getState()
 
         LaunchedEffect(behaviorState) {


### PR DESCRIPTION
…related components
This pull request includes changes to the `tenugui` library to replace the use of `String` with `UUID` for dialog identifiers. This change improves the uniqueness and reliability of dialog IDs across the library. The most important changes include modifications to the method signatures, imports, and test cases to accommodate the new `UUID` type.

Changes to method signatures and imports:

* [`tenugui/api/tenugui.api`](diffhunk://#diff-79ed06e74161df1358ace64976fc62c42c2cede739f22b666be320a7cd87e0cdL90-R90): Updated method signatures in `BottomSheetDialogKt`, `BottomSheetDialogStateKt`, and `BottomSheetDialogWrapper` to use `UUID` instead of `String`. [[1]](diffhunk://#diff-79ed06e74161df1358ace64976fc62c42c2cede739f22b666be320a7cd87e0cdL90-R90) [[2]](diffhunk://#diff-79ed06e74161df1358ace64976fc62c42c2cede739f22b666be320a7cd87e0cdL175-R181)
* [`tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialog.kt`](diffhunk://#diff-2556e5d48c915041f22d0990e7d419d5e24cb8a61ceca60af2068e9068195d49L50-R51): Changed the `dialogId` parameter from `String` to `UUID` in the `BottomSheetDialog` function.
* [`tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogState.kt`](diffhunk://#diff-44bb0daa0b474b35881fba67991ef02e50ef7bdf52db313501fa472140e4c1f2R44): Added `UUID` import and updated `rememberBottomSheetDialogState` function to use `UUID` for `dialogId`. [[1]](diffhunk://#diff-44bb0daa0b474b35881fba67991ef02e50ef7bdf52db313501fa472140e4c1f2R44) [[2]](diffhunk://#diff-44bb0daa0b474b35881fba67991ef02e50ef7bdf52db313501fa472140e4c1f2R159-R166)
* [`tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogWrapper.kt`](diffhunk://#diff-a72d84d2eaca34373e2f0005955e4287ea58824eea252ae7d860d88c6b7beff2R50-R58): Updated constructor to use `UUID` instead of `String` for `dialogId`.

Updates to test cases:

* [`tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/CollapsedTest.kt`](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L57-R61): Replaced `String` with `UUID` for `dialogId` in multiple test functions to ensure compatibility with the new method signatures. [[1]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L57-R61) [[2]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L81-R85) [[3]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L105-R109) [[4]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L133-R137) [[5]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L157-R161) [[6]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L181-R185) [[7]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L209-R215) [[8]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L236-R241) [[9]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L263-R267) [[10]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L294-R297) [[11]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L321-R323) [[12]](diffhunk://#diff-dc6a8b3cb3e5955e87cbe7b077fa98bf3046b477a7edff4786bedb0e70441579L348-R349)
* [`tests/src/androidTest/java/io/github/ryunen344/tenugui/tests/ExpandedTest.kt`](diffhunk://#diff-17ca8929c27d2215de2653464b641e48a50dbf84be75e01a9bb10874deb387fcL58-L63): Updated `dialogId` from `String` to `UUID` in test functions to reflect the new method signatures. [[1]](diffhunk://#diff-17ca8929c27d2215de2653464b641e48a50dbf84be75e01a9bb10874deb387fcL58-L63) [[2]](diffhunk://#diff-17ca8929c27d2215de2653464b641e48a50dbf84be75e01a9bb10874deb387fcL85-L90) [[3]](diffhunk://#diff-17ca8929c27d2215de2653464b641e48a50dbf84be75e01a9bb10874deb387fcL113-L118)