### PR TITLE
feat: enable composition creation in setContent method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .idea/artifacts
 .idea/AndroidProjectSystem.xml
 .idea/androidTestResultsUserPreferences.xml
+.idea/appInsightsSettings.xml
 .idea/compiler.xml
 .idea/inspectionProfiles
 .idea/deploymentTargetSelector.xml

--- a/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogLayout.kt
+++ b/tenugui/src/main/java/io/github/ryunen344/tenugui/BottomSheetDialogLayout.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.AbstractComposeView
@@ -46,10 +47,12 @@ internal class BottomSheetDialogLayout(
     override var shouldCreateCompositionOnAttachedToWindow: Boolean = false
         private set
 
+    @OptIn(InternalComposeUiApi::class)
     fun setContent(parent: CompositionContext, content: @Composable () -> Unit) {
         setParentCompositionContext(parent)
         this.content = content
         shouldCreateCompositionOnAttachedToWindow = true
+        createComposition()
     }
 
     @Composable

--- a/tests/src/main/java/io/github/ryunen344/tenugui/tests/LauncherActivity.kt
+++ b/tests/src/main/java/io/github/ryunen344/tenugui/tests/LauncherActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
@@ -44,6 +45,7 @@ class LauncherActivity : AppCompatActivity() {
                 Scaffold {
                     Column(
                         modifier = Modifier
+                            .safeDrawingPadding()
                             .fillMaxSize()
                             .padding(it),
                         verticalArrangement = Arrangement.spacedBy(24.dp),

--- a/tests/src/main/java/io/github/ryunen344/tenugui/tests/ui/BottomSheetContent.kt
+++ b/tests/src/main/java/io/github/ryunen344/tenugui/tests/ui/BottomSheetContent.kt
@@ -21,22 +21,24 @@
 package io.github.ryunen344.tenugui.tests.ui
 
 import android.util.Log
+import android.widget.EditText
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -44,18 +46,18 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
-import com.google.android.material.bottomsheet.BottomSheetBehavior
+import androidx.compose.ui.viewinterop.AndroidView
 import io.github.ryunen344.tenugui.BottomSheetDialog
 import io.github.ryunen344.tenugui.rememberBottomSheetDialogState
-import kotlinx.coroutines.delay
 import java.util.UUID
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BottomSheetContent(decorFitsSystemWindows: Boolean) {
     var visible by rememberSaveable { mutableStateOf(false) }
-    var text by rememberSaveable { mutableStateOf("false") }
+
 
     Scaffold { innerPadding ->
         Column(
@@ -99,74 +101,94 @@ fun BottomSheetContent(decorFitsSystemWindows: Boolean) {
 
     if (visible) {
         val dialogId = rememberSaveable { UUID.randomUUID() }
-        LocalDensity.current
         val bottomSheetDialogState = rememberBottomSheetDialogState(decorFitsSystemWindows = decorFitsSystemWindows)
-        val behaviorState by bottomSheetDialogState.behavior.getState()
 
-        LaunchedEffect(behaviorState) {
-            Log.e("BehaviorState", "BehaviorState is $behaviorState")
-        }
-
-        LaunchedEffect(key1 = bottomSheetDialogState) {
-            @Suppress("MagicNumber")
-            delay(3000)
-            bottomSheetDialogState.behavior.setState(BottomSheetBehavior.STATE_HALF_EXPANDED)
-        }
-
+//        Dialog(
+//            onDismissRequest = { visible = false },
+//            content = Content,
+//        )
+//
         BottomSheetDialog(
             onDismissRequest = {
                 visible = false
             },
             dialogId = dialogId,
             state = bottomSheetDialogState,
+            content = Content,
+        )
+//
+//        ModalBottomSheet(
+//            onDismissRequest = {
+//                visible = false
+//            },
+//            content = {
+//                Content()
+//            },
+//        )
+    }
+}
+
+private val Content: @Composable () -> Unit = {
+    var text by rememberSaveable { mutableStateOf("false") }
+    Column(
+        modifier = Modifier
+            .background(Color.Cyan)
+            .verticalScroll(rememberScrollState())
+            .fillMaxWidth()
+            .wrapContentHeight(),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            Column(
-                modifier = Modifier
-                    .background(Color.Cyan)
-                    .fillMaxSize()
-                    .statusBarsPadding()
-                    .navigationBarsPadding()
-                    .imePadding(),
-            ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(
-                        modifier = Modifier.padding(16.dp),
-                        text = "first item",
-                    )
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "first item",
+            )
 
-                    Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.weight(1f))
 
-                    Text(
-                        modifier = Modifier.padding(16.dp),
-                        text = "first item",
-                    )
-                }
-
-                TextField(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    value = text,
-                    onValueChange = {
-                        text = it
-                    },
-                )
-
-                @Suppress("MagicNumber")
-                repeat(33) {
-                    Text(
-                        modifier = Modifier.padding(16.dp),
-                        text = "column $it",
-                    )
-                }
-
-                Text(
-                    modifier = Modifier.padding(16.dp),
-                    text = "last item",
-                )
-            }
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "first item",
+            )
         }
+
+        AndroidView(
+            factory = ::EditText,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        ) {
+            it.setText(text)
+        }
+
+        TextField(
+            modifier = Modifier
+                .pointerInput(UUID.randomUUID()) {
+                    detectTapGestures {
+                        Log.wtf("TextField", "pointerInput $size")
+                        Log.wtf("TextField", "detectTapGestures $it")
+                    }
+                }
+                .fillMaxWidth()
+                .padding(16.dp),
+            value = text,
+            onValueChange = {
+                text = it
+            },
+        )
+
+        @Suppress("MagicNumber")
+        repeat(33) {
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = "column $it",
+            )
+        }
+
+        Text(
+            modifier = Modifier.padding(16.dp),
+            text = "last item",
+        )
     }
 }

--- a/tests/src/main/java/io/github/ryunen344/tenugui/tests/ui/BottomSheetContent.kt
+++ b/tests/src/main/java/io/github/ryunen344/tenugui/tests/ui/BottomSheetContent.kt
@@ -57,8 +57,7 @@ import java.util.UUID
 @Composable
 fun BottomSheetContent(decorFitsSystemWindows: Boolean) {
     var visible by rememberSaveable { mutableStateOf(false) }
-
-
+    
     Scaffold { innerPadding ->
         Column(
             modifier = Modifier

--- a/tests/src/main/java/io/github/ryunen344/tenugui/tests/ui/BottomSheetContent.kt
+++ b/tests/src/main/java/io/github/ryunen344/tenugui/tests/ui/BottomSheetContent.kt
@@ -57,7 +57,7 @@ import java.util.UUID
 @Composable
 fun BottomSheetContent(decorFitsSystemWindows: Boolean) {
     var visible by rememberSaveable { mutableStateOf(false) }
-    
+
     Scaffold { innerPadding ->
         Column(
             modifier = Modifier


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and layout of the `BottomSheetDialogLayout` and `BottomSheetContent` components in the `tenugui` project. The most important changes are grouped by theme below.

### Improvements to `BottomSheetDialogLayout`:

* Added `@OptIn(InternalComposeUiApi::class)` annotation to the `setContent` method and invoked `createComposition()` to ensure the composition is created when the content is set. [[1]](diffhunk://#diff-fc9852a74350395a1400ce8f263169838e6c516f2c8faab57b31f7ae124fe112R30) [[2]](diffhunk://#diff-fc9852a74350395a1400ce8f263169838e6c516f2c8faab57b31f7ae124fe112R50-R55)

### Enhancements to `LauncherActivity`:

* Added `safeDrawingPadding` to the `Column` modifier in `LauncherActivity` to improve the layout and ensure proper padding. [[1]](diffhunk://#diff-61667282d53131373ec4a492d504c6a0bdc4393306749f4cd26075635b066a66R31) [[2]](diffhunk://#diff-61667282d53131373ec4a492d504c6a0bdc4393306749f4cd26075635b066a66R48)

### Updates to `BottomSheetContent`:

* Introduced `ExperimentalMaterial3Api` annotation and moved the content of `BottomSheetContent` to a private `Content` composable function. [[1]](diffhunk://#diff-55d8b9177f24a7c0f8d95b13eb49c292c0b455c674bfd355ee00b5a38ba649afR24-R60) [[2]](diffhunk://#diff-55d8b9177f24a7c0f8d95b13eb49c292c0b455c674bfd355ee00b5a38ba649afL102-R138)
* Added an `AndroidView` with an `EditText` to the `Content` composable to allow for text input, and implemented `pointerInput` with `detectTapGestures` on the `TextField` to handle tap gestures and log interactions. [[1]](diffhunk://#diff-55d8b9177f24a7c0f8d95b13eb49c292c0b455c674bfd355ee00b5a38ba649afR156-R172) [[2]](diffhunk://#diff-55d8b9177f24a7c0f8d95b13eb49c292c0b455c674bfd355ee00b5a38ba649afL171-L172)