### PR TITLE
doc: update POM_DESCRIPTION to provide a clearer project overview

### DIFF
--- a/tenugui/gradle.properties
+++ b/tenugui/gradle.properties
@@ -1,2 +1,2 @@
 POM_NAME=tenugui
-POM_DESCRIPTION=tenugui
+POM_DESCRIPTION=Tenugui is a ModalBottomSheet wrapper for Jetpack Compose.


### PR DESCRIPTION
This pull request includes a small change to the `gradle.properties` file. The change updates the `POM_DESCRIPTION` to provide a more detailed description of the `tenugui` project.

* [`tenugui/gradle.properties`](diffhunk://#diff-66d1ffb473dc9f0cbd0ff9ee35742c8503ef0e71d52aa2041be92e3131ef22dcL2-R2): Updated `POM_DESCRIPTION` to "Tenugui is a ModalBottomSheet wrapper for Jetpack Compose."