### PR TITLE
chore: do not cancel workflow on main branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: check-${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.ref_name == 'main' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request modifies the concurrency settings in the GitHub Actions workflow to refine the behavior of canceling in-progress jobs based on the branch being processed.

Workflow behavior update:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L16-R16): Changed the `cancel-in-progress` setting to only cancel jobs if the branch is not `main`, using the `contains` function for conditional logic.